### PR TITLE
Update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,12 +31,12 @@
   },
   "license": "MIT",
   "dependencies": {
-    "chalk": "^0.5.0",
-    "readable-stream": "^1.1.13"
+    "chalk": "^1.1.1",
+    "readable-stream": "^2.0.2"
   },
   "devDependencies": {
-    "chai": "^1.9.1",
-    "mocha": "^1.18.2",
+    "chai": "^3.3.0",
+    "mocha": "^2.3.3",
     "jshint": "^2.5.0"
   }
 }


### PR DESCRIPTION
Pretty straightforward - update upstream.

Motivation was support for `FORCE_COLOR` in Chalk.
